### PR TITLE
feat(auth): 增加多個認證端點以支援不同的身份驗證方式

### DIFF
--- a/scripts/cms_sync.py
+++ b/scripts/cms_sync.py
@@ -14,6 +14,14 @@ def require_env(name: str) -> str:
     return value
 
 
+def normalize_base_url(raw: str) -> str:
+    base = raw.rstrip("/")
+    for suffix in ("/api", "/_"):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+    return base
+
+
 def load_updates(raw: str) -> dict[str, Any]:
     try:
         payload = json.loads(raw)
@@ -59,16 +67,33 @@ def authenticate(base_url: str) -> str:
 
     email = require_env("POCKETBASE_SUPERUSER_EMAIL")
     password = require_env("POCKETBASE_SUPERUSER_PASSWORD")
-    auth_url = f"{base_url}/api/collections/_superusers/auth-with-password"
-    auth = make_request(
-        "POST",
-        auth_url,
-        payload={"identity": email, "password": password},
-    )
-    auth_token = auth.get("token")
-    if not auth_token:
-        raise RuntimeError("PocketBase auth response did not include a token")
-    return f"Bearer {auth_token}"
+    auth_candidates = [
+        (
+            f"{base_url}/api/collections/_superusers/auth-with-password",
+            {"identity": email, "password": password},
+        ),
+        (
+            f"{base_url}/api/admins/auth-with-password",
+            {"identity": email, "password": password},
+        ),
+        (
+            f"{base_url}/api/admins/auth-with-password",
+            {"email": email, "password": password},
+        ),
+    ]
+    errors: list[str] = []
+    for auth_url, payload in auth_candidates:
+        try:
+            auth = make_request("POST", auth_url, payload=payload)
+            auth_token = auth.get("token")
+            if not auth_token:
+                raise RuntimeError("PocketBase auth response did not include a token")
+            return f"Bearer {auth_token}"
+        except RuntimeError as exc:
+            errors.append(f"{auth_url}: {exc}")
+
+    joined = "\n".join(errors)
+    raise RuntimeError(f"PocketBase authentication failed with all known endpoints:\n{joined}")
 
 
 def resolve_record(
@@ -148,7 +173,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     updates = load_updates(args.updates_json)
-    base_url = require_env("POCKETBASE_URL").rstrip("/")
+    base_url = normalize_base_url(require_env("POCKETBASE_URL"))
     token = authenticate(base_url)
     record = resolve_record(base_url, token, args.collection, args.record_id, args.filter)
 


### PR DESCRIPTION
This pull request introduces improvements to the PocketBase authentication logic and URL handling in the `scripts/cms_sync.py` script. The main changes focus on making authentication more robust by supporting multiple endpoints and normalizing the base URL to prevent errors caused by trailing suffixes.

Authentication improvements:

* The `authenticate` function now attempts authentication using multiple endpoint and payload combinations, falling back gracefully and aggregating errors if all options fail. This increases compatibility with different PocketBase setups.

URL normalization:

* Added a new `normalize_base_url` function to strip trailing slashes and common suffixes from the PocketBase URL, ensuring consistent and correct API endpoint construction throughout the script.
* Updated the main entry point to use `normalize_base_url` instead of manual string manipulation when obtaining the base URL.## Summary

Describe the change in a few sentences.

## Related Issue

Closes #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Content update
- [ ] Refactor
- [ ] Documentation
- [ ] Deployment or CI

## AI Source

- [ ] GitHub Copilot coding agent
- [ ] Codex-assisted
- [ ] Manual only

## Production Data Impact

- [ ] No production data change
- [ ] Separate CMS workflow required
- [ ] CMS workflow already executed and verified

## What Changed

- 

## Validation

- [ ] Local validation completed
- [ ] GitHub Actions passed
- [ ] Manual review completed

## Risks or Notes

List any risks, assumptions, or follow-up work.
